### PR TITLE
Add link_names element to format bot message without the angled brackets.

### DIFF
--- a/api/slack.py
+++ b/api/slack.py
@@ -68,4 +68,5 @@ def webhook():
             dic = content
         else:
             dic = {"text": content}
+        dic["link_names"] = 1
     return Response(Utils().dump_json(dic), mimetype='application/json')


### PR DESCRIPTION
Add link_names element to format bot message without the angled brackets.
- About 2 days before, I've got a issue that message formatting of channel string does not work well.
  In iOS and Android client, channel string is garbled with "#unknown-channel" (on iOS) or "#deleted-channel" (on Android)
- On inquiry for slack team, they sent me the solution of adding `"link_names":1` element in Outgoing-webhook response as below.
  This PullRequest has this fix :grinning: 

```
{
"text":"#channel", "link_names":1
}
``
```
